### PR TITLE
messy reproduction

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "mathbox": "^2.1.2",
-        "mathbox-react": "^0.0.6",
+        "mathbox-react": "file:../mathbox-react-0.0.6.tgz",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
@@ -10704,8 +10704,9 @@
     },
     "node_modules/mathbox-react": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mathbox-react/-/mathbox-react-0.0.6.tgz",
-      "integrity": "sha512-CpWXBxlMFoG2vmUAWRXCFMLn0kYeS7gSs3lP6Chux0aFFQdr6wC4AAOMVjfNrN/xgNlSMJNqpXOgQ+KKOtaILw==",
+      "resolved": "file:../mathbox-react-0.0.6.tgz",
+      "integrity": "sha512-b+zrsP33PVLSnE+y31ogR8W+YxmY9hPHxu9in4bw2h3JBxbjtkMNIBKVulZWGHDMaWcRz8W3E5R552UyLzUvPw==",
+      "license": "ISC",
       "peerDependencies": {
         "mathbox": "^2.1.2",
         "react": "^17.0.2",
@@ -23606,9 +23607,8 @@
       }
     },
     "mathbox-react": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mathbox-react/-/mathbox-react-0.0.6.tgz",
-      "integrity": "sha512-CpWXBxlMFoG2vmUAWRXCFMLn0kYeS7gSs3lP6Chux0aFFQdr6wC4AAOMVjfNrN/xgNlSMJNqpXOgQ+KKOtaILw==",
+      "version": "file:../mathbox-react-0.0.6.tgz",
+      "integrity": "sha512-b+zrsP33PVLSnE+y31ogR8W+YxmY9hPHxu9in4bw2h3JBxbjtkMNIBKVulZWGHDMaWcRz8W3E5R552UyLzUvPw==",
       "requires": {}
     },
     "mdn-data": {

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "mathbox": "^2.1.2",
-    "mathbox-react": "^0.0.6",
+    "mathbox-react": "file:../mathbox-react-0.0.6.tgz",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,17 +16,27 @@ function App() {
   const [width, setWidth] = useState(32)
   const [height, setHeight] = useState(32)
   const [size, setSize] = useState(16)
+  const [show, setShow] = useState(true)
   const [expr, setExpr] = useState<AreaEmitter>(() => expr1)
 
+  // @ts-ignore
+  if (!window.boxes) {
+    // @ts-ignore
+    window.boxes = []
+  }
   const setup = useCallback((mathbox: MathboxSelection<"root"> | null) => {
     if (mathbox === null) return
     console.log("setup!")
+    // @ts-ignore
+    window.boxes.push(mathbox)
     mathbox.three.camera.position.set(1, 1, 2)
   }, [])
 
   return (
     <>
       <PointsForm
+        show={show}
+        setShow={setShow}
         width={width}
         setWidth={setWidth}
         height={height}
@@ -36,7 +46,14 @@ function App() {
         expr={expr}
         setExpr={setExpr}
       />
-      <MB.Mathbox ref={setup} options={mathboxOptions} className="h-100">
+      <MB.Mathbox
+        showMathbox={show}
+        id="cat"
+        key="cat"
+        ref={setup}
+        options={mathboxOptions}
+        className="h-100"
+      >
         <MB.Cartesian>
           <MB.Grid axes="xz" />
           <Points width={width} height={height} size={size} expr={expr} />

--- a/example/src/PointsForm.tsx
+++ b/example/src/PointsForm.tsx
@@ -18,6 +18,8 @@ const exprOptions = [
 ]
 
 type Props = {
+  show: boolean
+  setShow: (value: boolean) => void
   size: number
   setSize: (value: number) => void
   width: number
@@ -81,6 +83,16 @@ const PointsForm = (props: Props) => {
           </option>
         ))}
       </select>
+      <label htmlFor="show">Show</label>
+      <span></span>
+      <input
+        id="show"
+        type="checkbox"
+        checked={props.show}
+        onChange={(e) => {
+          props.setShow(e.target.checked)
+        }}
+      />
     </div>
   )
 }

--- a/src/components/Mathbox.tsx
+++ b/src/components/Mathbox.tsx
@@ -10,6 +10,7 @@ import { mathBox, MathboxSelection, MathBoxOptions } from "mathbox"
 import MathboxAPIContext from "./MathboxNodeContext"
 
 type Props = {
+  showMathbox?: boolean
   options?: MathBoxOptions
   initialCameraPosition?: number[]
 } & React.HTMLProps<HTMLDivElement>
@@ -18,7 +19,8 @@ const Mathbox = (
   props: Props,
   ref: React.Ref<MathboxSelection<"root"> | null>
 ) => {
-  const { children, initialCameraPosition, options, ...divProps } = props
+  const { children, initialCameraPosition, options, showMathbox, ...divProps } =
+    props
   const mathboxOptions = useMemo(() => options ?? {}, [options])
   const [selection, setSelection] = useState<MathboxSelection<"root"> | null>(
     null
@@ -26,7 +28,7 @@ const Mathbox = (
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
   useEffect(() => {
     if (!container) return () => {}
-
+    if (!showMathbox) return () => {}
     const mathbox = mathBox({
       ...mathboxOptions,
       element: container,
@@ -44,13 +46,15 @@ const Mathbox = (
       mathbox.select("*").remove()
       mathbox.three.destroy()
     }
-  }, [container, mathboxOptions, initialCameraPosition])
+  }, [container, mathboxOptions, initialCameraPosition, showMathbox])
   useImperativeHandle(ref, () => selection, [selection])
   return (
     <div ref={setContainer} {...divProps}>
-      <MathboxAPIContext.Provider value={selection}>
-        {children}
-      </MathboxAPIContext.Provider>
+      {showMathbox && (
+        <MathboxAPIContext.Provider value={selection}>
+          {children}
+        </MathboxAPIContext.Provider>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
This is not a real PR, just a reproduction of an issue.

To see the issue:
1. Clone this branch
2. Run `npm pack` in the root
3. Then `npm run start --prefix examples` to start the example
4. Open the example in a browser... Look at App.tsx and see how it puts mathbox references in a global `boxes` array.
5. **in browser console:** `boxes[0].print()` ... mathbox has stuff in it!
6. uncheck the "Show" checkbox. Mathbox disappears.
7. **in browser console:** `boxes[0].print()` ... mathbox has no stuff! Good! We killed it!
8. re-check the Show checkbox
9. **in browser console**:
    - `boxes[1].print()` has no stuff.... where is it???
    - `boxes[0].print()` has the stuff! but it should not....
