### PR TITLE
fix rerendering errors

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "mathbox": "^2.1.2",
-    "mathbox-react": "0.0.7-dev",
+    "mathbox-react": "0.0.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbox-react",
-  "version": "0.0.7-dev",
+  "version": "0.0.7",
   "description": "React wrapper for Mathbox",
   "license": "ISC",
   "author": "Chris Chudzicki",

--- a/src/components/Cartesian.spec.tsx
+++ b/src/components/Cartesian.spec.tsx
@@ -1,13 +1,30 @@
-import React from "react"
-import { render } from "@testing-library/react"
+import React, { useState } from "react"
+import { render, act } from "@testing-library/react"
+import { MathboxSelection } from "mathbox"
 import ContainedMathbox from "./ContainedMathbox"
+import Mathbox from "./Mathbox"
 import { Cartesian, Grid } from "./components"
 import { MathboxRef } from "./types"
 
-function assertNotUndefined<T>(value: T | undefined): asserts value is T {
+function assertNotNil<T>(value: T): asserts value is NonNullable<T> {
   if (value === undefined) {
     throw new Error("Unexpected undefined value")
   }
+  if (value === null) {
+    throw new Error("Unexpected null value")
+  }
+}
+
+/**
+ * Assert that two mathbox selections have the same nodes in the same order.
+ */
+const assertSelectionsEqual = (s1: MathboxSelection, s2: MathboxSelection) => {
+  expect(s1.length).toBe(s2.length)
+  Array(s1.length)
+    .fill(null)
+    .forEach((_, i) => {
+      expect(s1[i]).toBe(s2[i])
+    })
 }
 
 describe("Cartesian", () => {
@@ -73,7 +90,7 @@ describe("Cartesian", () => {
     )
     const cartesian = mbRef.current?.select<"cartesian">("cartesian")
 
-    assertNotUndefined(cartesian)
+    assertNotNil(cartesian)
 
     expect(cartesian.get("visible")).toBe(props.visible)
     // Mathbox converts scale to a ThreeJS Vec3
@@ -88,7 +105,7 @@ describe("Cartesian", () => {
       </ContainedMathbox>
     )
     const cartesian = mbRef.current?.select<"cartesian">("cartesian")
-    assertNotUndefined(cartesian)
+    assertNotNil(cartesian)
 
     expect(cartesian.get("visible")).toBe(true)
     rerender(
@@ -97,5 +114,91 @@ describe("Cartesian", () => {
       </ContainedMathbox>
     )
     expect(cartesian.get("visible")).toBe(false)
+  })
+
+  it("re-renders inside new instance when root changes", () => {
+    const mbRef: MathboxRef<"root"> = { current: null }
+    const cartesianRef: MathboxRef<"cartesian"> = { current: null }
+    const gridRef: MathboxRef<"grid"> = { current: null }
+    const options1 = {}
+    const { rerender } = render(
+      <ContainedMathbox ref={mbRef} options={options1}>
+        <Cartesian ref={cartesianRef}>
+          <Grid ref={gridRef} />
+        </Cartesian>
+      </ContainedMathbox>
+    )
+
+    const mb1 = mbRef.current
+    const cartesian1 = cartesianRef.current
+    const grid1 = gridRef.current
+    assertNotNil(mb1)
+    assertNotNil(cartesian1)
+    assertNotNil(grid1)
+
+    expect(cartesian1).toHaveLength(1)
+    assertSelectionsEqual(mb1.select("cartesian"), cartesian1)
+    expect(grid1).toHaveLength(1)
+    assertSelectionsEqual(mb1.select("grid"), grid1)
+
+    /**
+     * When re-rendered, this will create a new mathBox since the options
+     * object prop will have changed.
+     */
+    const options2 = {}
+    expect(options1).not.toBe(options2)
+
+    rerender(
+      <ContainedMathbox ref={mbRef} options={options2}>
+        <Cartesian ref={cartesianRef}>
+          <Grid ref={gridRef} />
+        </Cartesian>
+      </ContainedMathbox>
+    )
+
+    const mb2 = mbRef.current
+    const cartesian2 = cartesianRef.current
+    const grid2 = gridRef.current
+    assertNotNil(mb2)
+    assertNotNil(cartesian2)
+    assertNotNil(grid2)
+
+    // It creates a new instance b/c the options prop has changed by reference
+    expect(mb1).not.toBe(mb2)
+
+    expect(cartesian2).toHaveLength(1)
+    assertSelectionsEqual(mb2.select("cartesian"), cartesian2)
+    expect(grid2).toHaveLength(1)
+    assertSelectionsEqual(mb2.select("grid"), grid2)
+  })
+
+  it("Can render a new instance without error", async () => {
+    const mbRef: MathboxRef<"root"> = { current: null }
+    let containerDiv: HTMLDivElement | null = null
+    let setKey: (key: string) => void
+    const KeyedMathbox = () => {
+      const [container, setContainer] = useState<HTMLDivElement | null>(null)
+      const [key, setKeyState] = useState("key-0")
+      setKey = setKeyState
+      containerDiv = container
+      return (
+        <div ref={setContainer} key={key}>
+          {container && (
+            <Mathbox ref={mbRef} container={container}>
+              <Cartesian />
+            </Mathbox>
+          )}
+        </div>
+      )
+    }
+    render(<KeyedMathbox />)
+
+    assertNotNil(mbRef.current)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    act(() => setKey!("key-2"))
+
+    assertNotNil(containerDiv)
+    expect(mbRef.current.three.element).toBe(containerDiv)
+    expect(mbRef.current.select("cartesian").length).toBe(1)
   })
 })

--- a/src/components/components.tsx
+++ b/src/components/components.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react"
 import { Props, NodeType, MathboxSelection } from "mathbox"
 import MathboxAPIContext from "./MathboxNodeContext"
-import { useMathboxAPI } from "./hooks"
+import { useMathboxAPI, isSelectionParent } from "./hooks"
 import { WithChildren } from "./types"
 
 type MathboxComponent<T extends NodeType> = React.ForwardRefExoticComponent<
@@ -15,9 +15,12 @@ const mathboxComponentFactory = <T extends NodeType>(
     props: WithChildren<Props[T]>,
     ref: React.Ref<MathboxSelection<T> | null>
   ) => {
-    const nodeAPI = useMathboxAPI(type, props, ref)
+    const { selection, parent } = useMathboxAPI(type, props, ref)
+    if (!selection) return null
+    if (!parent) return null
+    if (!isSelectionParent(selection, parent)) return null
     return (
-      <MathboxAPIContext.Provider value={nodeAPI}>
+      <MathboxAPIContext.Provider value={selection}>
         {props.children}
       </MathboxAPIContext.Provider>
     )

--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -8,6 +8,32 @@ import type { MathboxSelection, NodeType, Props } from "mathbox"
 import MathboxAPIContext from "./MathboxNodeContext"
 import type { WithChildren } from "./types"
 
+type WithPrivateUp = MathboxSelection & { _up: WithPrivateUp | null }
+
+/**
+ * Check that parent is actually the selection's parent.
+ * The mathbox components occasionally render with a selection value whose
+ * parent does not match the parent specified in MathboxContext.
+ *
+ * I believe this fundamentally this is happening because
+ * - we store parent value in context...
+ * - we update the context parent value using useEffect hooks..
+ * - useEffect hooks are called children before parents.
+ *
+ * One wonders whether we really need to be using useEffect hooks for the
+ * mathbox components, or if we can just put all the node creation/removal stuff
+ * in a render function. Hooks seem nice for dependencies, but mathbox is pretty
+ * smart about diffing out the actual changes.
+ */
+export const isSelectionParent = (
+  selection: MathboxSelection,
+  parent: MathboxSelection
+) => {
+  // eslint-disable-next-line no-underscore-dangle
+  const selectionParentNode = (selection as WithPrivateUp)._up?.[0]
+  return selectionParentNode === parent[0]
+}
+
 export const useMathboxAPI = <T extends NodeType>(
   name: T,
   props: WithChildren<Props[T]>,
@@ -23,13 +49,13 @@ export const useMathboxAPI = <T extends NodeType>(
         setSelection(null)
       }
     },
-    [selection]
+    [selection, parent]
   )
 
   useEffect(() => {
     const { children, ...mbProps } = props
     if (!parent) return
-    if (!selection) {
+    if (!selection || !isSelectionParent(selection, parent)) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const thisNode: MathboxSelection<T> = parent[name](mbProps)
@@ -48,5 +74,5 @@ export const useMathboxAPI = <T extends NodeType>(
 
   useImperativeHandle(ref, () => selection, [selection])
 
-  return selection
+  return { selection, parent }
 }


### PR DESCRIPTION
This commit fixes issues with children rendeirng inside outdated parents. Two things:

First: when parents change, destroy the old children and create new ones.  We weren't doing that before.

Second: Check that the parent-according-to-react is the same as the parent-according-to-mathbox. If they are different, destroy-and-create as above...

But...why might they be different? I believe fundamentally the issue is:
- we store parent value in context...
- we update the context parent value using useEffect hooks..
- useEffect hooks are called children before parents.

One wonders whether we really need to be using useEffect hooks for the mathbox components, or if we can just put all the node creation/removal stuff in the render function. Hooks seem nice for dependencies, but mathbox is pretty smart about diffing out the actual changes.