### PR TITLE
only allow some components to have children

### DIFF
--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from "react-dom/client"
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 import DancingPoints from "./views/DancingPoints"
+import ColorCube from "./views/ColorCube"
 import "./index.css"
 
 const root = ReactDOM.createRoot(document.getElementById("root")!)
@@ -9,6 +10,7 @@ root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<DancingPoints />} />
+      <Route path="/color-cube" element={<ColorCube />} />
     </Routes>
   </BrowserRouter>
 )

--- a/example/src/views/ColorCube.tsx
+++ b/example/src/views/ColorCube.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useState } from "react"
+import { MathboxSelection } from "mathbox"
+import * as MB from "mathbox-react"
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
+import { useForm } from "react-hook-form"
+
+const mathboxOptions = {
+  plugins: ["core", "controls", "cursor"],
+  controls: {
+    klass: OrbitControls,
+  },
+}
+
+export default function ColorCube() {
+  const [formValues, setFormValues] = useState<FormValues>(defaultFormValues)
+  const setup = useCallback((mathbox: MathboxSelection<"root"> | null) => {
+    // @ts-ignore
+    window.mathbox = mathbox
+    if (mathbox === null) return
+    mathbox.three.camera.position.set(1, 1, 2)
+  }, [])
+  return (
+    <>
+      <ControlsForm onChange={setFormValues} />
+      <MB.ContainedMathbox
+        options={mathboxOptions}
+        ref={setup}
+        containerStyle={{ height: "500px" }}
+      >
+        <MB.Cartesian
+          range={[
+            [0, 1],
+            [0, 1],
+            [0, 1],
+          ]}
+          scale={[1, 1, 1]}
+        >
+          <MB.Volume
+            id="volume"
+            width={formValues.width}
+            height={formValues.height}
+            depth={formValues.depth}
+            items={1}
+            channels={4}
+            expr={(emit, x, y, z) => {
+              emit(x, y, z, formValues.opacity)
+            }}
+          />
+          <MB.Point
+            points="#volume"
+            colors="#volume"
+            size={formValues.size}
+            color={0xffffff}
+          />
+        </MB.Cartesian>
+      </MB.ContainedMathbox>
+    </>
+  )
+}
+
+interface FormValues {
+  opacity: number
+  size: number
+  width: number
+  height: number
+  depth: number
+}
+const defaultFormValues: FormValues = {
+  opacity: 0.75,
+  size: 4,
+  width: 16,
+  height: 16,
+  depth: 16,
+}
+
+interface ControlsFormProps {
+  onChange: (values: FormValues) => void
+}
+
+function ControlsForm({ onChange }: ControlsFormProps) {
+  const { register, watch } = useForm<FormValues>()
+  const values = watch()
+  const onFormChange = useCallback(() => onChange(watch()), [onChange, watch])
+  return (
+    <form onChange={onFormChange}>
+      <>
+        <label>Opacity</label>
+        <span>{values.opacity}</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          defaultValue={defaultFormValues.opacity}
+          {...register("opacity", { valueAsNumber: true })}
+        />
+      </>
+      <>
+        <label>Size</label>
+        <span>{values.size}</span>
+        <input
+          type="range"
+          min={1}
+          max={32}
+          step={1}
+          defaultValue={defaultFormValues.size}
+          {...register("size", { valueAsNumber: true })}
+        />
+      </>
+      <>
+        <label>Width</label>
+        <span>{values.width}</span>
+        <input
+          type="range"
+          min={1}
+          max={64}
+          step={1}
+          defaultValue={defaultFormValues.width}
+          {...register("width", { valueAsNumber: true })}
+        />
+      </>
+      <>
+        <label>Height</label>
+        <span>{values.height}</span>
+        <input
+          type="range"
+          min={1}
+          max={64}
+          step={1}
+          defaultValue={defaultFormValues.height}
+          {...register("height", { valueAsNumber: true })}
+        />
+      </>
+      <>
+        <label>Depth</label>
+        <span>{values.depth}</span>
+        <input
+          type="range"
+          min={1}
+          max={64}
+          step={1}
+          defaultValue={defaultFormValues.depth}
+          {...register("depth", { valueAsNumber: true })}
+        />
+      </>
+    </form>
+  )
+}

--- a/example/src/views/DancingPoints.tsx
+++ b/example/src/views/DancingPoints.tsx
@@ -12,7 +12,7 @@ const mathboxOptions = {
   },
 }
 
-export default function App() {
+export default function DancingPoints() {
   const [container, setContainer] = useState<HTMLElement | null>(null)
   const [formValues, setFormValues] = useState<FormValues>(defaultFormValues)
   const [emitter, setEmitter] = useState<AreaEmitter>(() => {})
@@ -58,7 +58,7 @@ export default function App() {
   )
 }
 
-type FormValues = {
+interface FormValues {
   showPoints: boolean
   width: number
   height: number
@@ -66,7 +66,7 @@ type FormValues = {
   expr: string
   A: number
 }
-const defaultFormValues = {
+const defaultFormValues: FormValues = {
   showPoints: true,
   width: 48,
   height: 64,

--- a/src/components/components.spec.tsx
+++ b/src/components/components.spec.tsx
@@ -3,7 +3,7 @@ import { render, act } from "@testing-library/react"
 import { MathboxSelection } from "mathbox"
 import ContainedMathbox from "./ContainedMathbox"
 import Mathbox from "./Mathbox"
-import { Cartesian, Grid } from "./components"
+import { Cartesian, Grid, Voxel } from "./components"
 import { MathboxRef } from "./types"
 
 function assertNotNil<T>(value: T): asserts value is NonNullable<T> {
@@ -236,5 +236,23 @@ describe("Cartesian", () => {
 
     assertNotNil(mbRef.current)
     expect(mbRef.current.select("grid").length).toBe(0)
+  })
+})
+
+describe("<Voxel />", () => {
+  it("throws a runtime error if it has children", () => {
+    const willThrow = () =>
+      render(
+        <ContainedMathbox>
+          <Cartesian>
+            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment  */}
+            {/* @ts-ignore */}
+            <Voxel>
+              <Grid />
+            </Voxel>
+          </Cartesian>
+        </ContainedMathbox>
+      )
+    expect(willThrow).toThrow("Component <Voxel /> cannot have children.")
   })
 })

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { MathboxSelection } from "mathbox"
+import { MathboxSelection, NodeType } from "mathbox"
 
 type WithPrivateUp = MathboxSelection & { _up?: WithPrivateUp }
 
@@ -40,4 +40,40 @@ export const isSelectionParent = (
 ) => {
   const selectionParentNode = (selection as WithPrivateUp)._up?.[0]
   return selectionParentNode === parent[0]
+}
+
+const CAN_HAVE_CHILDREN = [
+  "view",
+  "cartesian",
+  "cartesian4",
+  "polar",
+  "spherical",
+  "stereographic",
+  "stereographic4",
+  "transform",
+  "transform4",
+  "vertex",
+  "fragment",
+  "layer",
+  "mask",
+  "group",
+  "inherit",
+  "root",
+  "unit",
+  "rtt",
+  "clock",
+  "now",
+  "move",
+  "present",
+  "reveal",
+  "slide",
+] as const
+
+export type ParentNodeTypes = typeof CAN_HAVE_CHILDREN[number]
+
+export const canNodeHaveChildren = (type: NodeType) => (CAN_HAVE_CHILDREN as readonly string[]).includes(type)
+
+export const capitalize = (s: string) => {
+  if (!s) return ""
+  return s[0].toLocaleUpperCase() + s.slice(1)
 }


### PR DESCRIPTION
### What are the related issues? #25 

### What does this PR do?
**tldr:** This PR make it so that only components which should have children can actually be given children, which avoids unnecessary re-renders. Also adds a color cube example.

Because the MathBox API is "fluid", i.e., designed around chaining, node creation can always be chained:

```js
const root = mathBox()

root
  .cartesian()  // create cartesian... parent = root
  .volume()     // create volume...    parent = cartesian
  .point()      // create point...     parent = cartesian
```

The `.point()` call might appear as if its parent would be volume, but in actuality its parent is cartesian.

Previously, mathbox-react allowed all components to have children. So this was allowed:

```
<Cartesian>
  <Volume>
    <Points />
  </Volume>
</Cartesian>
```
In order to ensure that the mathbox tree and react tree stay in-sync, mathbox-react checks that the react-node's parent and the mathbox-node parent are the same and re-renders if they are not. But the above component tree never gets in-sync, because MathBox always renders Point as a child of Cartesian, never as a child of Volume.

With this commit, mathbox-react becomes a bit more strict about children. Now, a component can only have children if mathbox will actually place the children on that node.

Resolves https://github.com/ChristopherChudzicki/mathbox-react/issues/25