### PR TITLE
Tighten up lodash import

### DIFF
--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { isEqual } from "lodash"
+import isEqual from "lodash/eqDeep"
 import { useRef, useMemo } from "react"
 import { MathboxSelection, NodeType } from "mathbox"
 

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import isEqual from "lodash/eqDeep"
+import isEqual from "lodash/isEqual"
 import { useRef, useMemo } from "react"
 import { MathboxSelection, NodeType } from "mathbox"
 


### PR DESCRIPTION
This PR pulls in `isEqual` from the tighter `eqDeep.js` vs the full `lodash.js`: https://github.com/lodash/lodash/blob/master/eqDeep.js