### PR TITLE
Cc/controls

### DIFF
--- a/packages/mathbox-react/package.json
+++ b/packages/mathbox-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbox-react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React wrapper for Mathbox",
   "license": "ISC",
   "repository": {

--- a/packages/mathbox-react/package.json
+++ b/packages/mathbox-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathbox-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React wrapper for Mathbox",
   "license": "ISC",
   "repository": {

--- a/packages/mathbox-react/src/index.ts
+++ b/packages/mathbox-react/src/index.ts
@@ -1,1 +1,4 @@
+import * as Threestrap from "./threestrap"
+
 export * from "./components"
+export { Threestrap }

--- a/packages/mathbox-react/src/threestrap/Controls.ts
+++ b/packages/mathbox-react/src/threestrap/Controls.ts
@@ -1,0 +1,43 @@
+/* eslint-disable react/no-unused-prop-types */
+import React, { useEffect } from "react"
+import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
+import { useThreestrap } from "./ThreestrapContext"
+import type { Threestrap } from "./threestrap"
+
+type OrbitControlsProps = {
+  type: "orbit"
+  enablePan?: boolean
+  enableRotate?: boolean
+  enableZoom?: boolean
+}
+type ControlsProps = OrbitControlsProps
+
+const ALLOWED_CONTROLS = ["orbit"]
+
+const useOrbitControls = (threestrap: Threestrap, props: ControlsProps) => {
+  useEffect(() => {
+    if (props.type !== "orbit") return
+    if (!threestrap.controls) return
+    const controls = threestrap.controls as OrbitControls
+    if (props.enablePan !== undefined) {
+      controls.enablePan = props.enablePan
+    }
+    if (props.enableZoom !== undefined) {
+      controls.enableZoom = props.enableZoom
+    }
+    if (props.enableRotate !== undefined) {
+      controls.enableRotate = props.enableRotate
+    }
+  })
+}
+
+const Controls: React.FC<ControlsProps> = (props) => {
+  if (!ALLOWED_CONTROLS.includes(props.type)) {
+    throw new Error(`Invalid control type ${props.type}`)
+  }
+  const threestrap = useThreestrap()
+  useOrbitControls(threestrap, props)
+  return null
+}
+
+export default Controls

--- a/packages/mathbox-react/src/threestrap/Controls.ts
+++ b/packages/mathbox-react/src/threestrap/Controls.ts
@@ -9,26 +9,59 @@ type OrbitControlsProps = {
   enablePan?: boolean
   enableRotate?: boolean
   enableZoom?: boolean
+  onStart?: (event: { type: "end"; target: OrbitControls }) => void
+  onEnd?: (event: { type: "end"; target: OrbitControls }) => void
 }
 type ControlsProps = OrbitControlsProps
 
 const ALLOWED_CONTROLS = ["orbit"]
 
-const useOrbitControls = (threestrap: Threestrap, props: ControlsProps) => {
+const useOrbitControls = (
+  threestrap: Threestrap,
+  { type, enablePan, enableRotate, enableZoom, onStart, onEnd }: ControlsProps
+) => {
   useEffect(() => {
-    if (props.type !== "orbit") return
+    if (type !== "orbit") return
     if (!threestrap.controls) return
     const controls = threestrap.controls as OrbitControls
-    if (props.enablePan !== undefined) {
-      controls.enablePan = props.enablePan
+    if (enablePan !== undefined) {
+      controls.enablePan = enablePan
     }
-    if (props.enableZoom !== undefined) {
-      controls.enableZoom = props.enableZoom
+    if (enableZoom !== undefined) {
+      controls.enableZoom = enableZoom
     }
-    if (props.enableRotate !== undefined) {
-      controls.enableRotate = props.enableRotate
+    if (enableRotate !== undefined) {
+      controls.enableRotate = enableRotate
     }
-  })
+  }, [type, enablePan, enableRotate, enableZoom, threestrap.controls])
+
+  useEffect(() => {
+    if (type !== "orbit") return () => {}
+    if (!threestrap.controls) return () => {}
+    const controls = threestrap.controls as OrbitControls
+    if (onStart) {
+      controls.addEventListener("start", onStart)
+    }
+    return () => {
+      if (onStart) {
+        controls.removeEventListener("start", onStart)
+      }
+    }
+  }, [type, onStart, threestrap.controls])
+
+  useEffect(() => {
+    if (type !== "orbit") return () => {}
+    if (!threestrap.controls) return () => {}
+    const controls = threestrap.controls as OrbitControls
+    if (onEnd) {
+      controls.addEventListener("end", onEnd)
+    }
+    return () => {
+      if (onEnd) {
+        controls.removeEventListener("end", onEnd)
+      }
+    }
+  }, [type, onEnd, threestrap.controls])
 }
 
 const Controls: React.FC<ControlsProps> = (props) => {

--- a/packages/mathbox-react/src/threestrap/index.ts
+++ b/packages/mathbox-react/src/threestrap/index.ts
@@ -1,2 +1,4 @@
 export { default as Renderer } from "./Renderer"
+export { default as Controls } from "./Controls"
+export { useThreestrap } from "./ThreestrapContext"
 export type { Threestrap } from "./threestrap"


### PR DESCRIPTION
Adds a Threestrap namespace export to `mathbox-react`; it exports all the stuff from `mathbox-react/threestrap`.

Adds a `<Threestrap.Controls />` component.