### PR TITLE
Create mathbox nodes in layout effects, with a real-browser regression test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,3 +15,17 @@ jobs:
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: yarn install --immutable
+      # Installs the Chromium build plus the Linux system libraries it needs.
+      # The examples app aliases `mathbox-react` to its TS source, so no build
+      # step is required before the Playwright specs run.
+      - run: yarn workspace examples exec playwright install --with-deps chromium
+      - run: yarn workspace examples test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ dist
 
 # turborepo
 .turbo
+
+# playwright
+test-results
+playwright-report
+
+# typescript
+*.tsbuildinfo

--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ["@mathbox-react/eslint-config"],
+  // vite.config.ts is typechecked by the node-tooling tsconfig (bundler
+  // resolution), not the browser-app tsconfig, so ESLint's type-aware parser
+  // needs both projects to cover every linted file.
+  parserOptions: {
+    project: ["./tsconfig.json", "./tsconfig.node.json"],
+  },
+}

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -14,8 +14,9 @@
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@types/react": "^18.0.26",
-    "@types/react-dom": "^18.0.9",
+    "@playwright/test": "^1.49",
+    "@types/react": "18.2.28",
+    "@types/react-dom": "^18.2.0",
     "@types/three": "0.148.0",
     "@vitejs/plugin-react": "^6",
     "eslint": "^8.32.0",
@@ -24,6 +25,7 @@
   "scripts": {
     "dev": "vite",
     "preview": "vite preview",
+    "test:e2e": "playwright test",
     "lint": "eslint \"**/*.ts?(x)\""
   }
 }

--- a/packages/examples/playwright.config.ts
+++ b/packages/examples/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/**
+ * Drives the examples app in a real browser so we can assert against real
+ * WebGL / real-frame behavior that jsdom cannot model — a smoke test of the
+ * scene graph, and the useLayoutEffect atomic-mount regression test. See the
+ * specs under src/playwright/.
+ *
+ * The examples app resolves `mathbox-react` to its TypeScript source (a Vite
+ * alias in vite.config.ts), so no build step is needed before running these.
+ */
+export default defineConfig({
+  testDir: "./src/playwright",
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "list" : "line",
+  use: {
+    baseURL: "http://localhost:5173",
+    launchOptions: {
+      // Headless Chromium needs software WebGL (SwiftShader) to run mathbox's
+      // WebGL context. Chromium 120+ requires --enable-unsafe-swiftshader to
+      // opt into it; without these flags the renderer segfaults.
+      args: [
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--enable-unsafe-swiftshader",
+      ],
+    },
+  },
+  webServer: {
+    command: "yarn dev --port 5173 --strictPort",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+})

--- a/packages/examples/src/index.tsx
+++ b/packages/examples/src/index.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom"
 import DancingPoints from "./views/DancingPoints"
 import ColorCube from "./views/ColorCube"
 import SimpleExample from "./views/SimpleExample"
+import TestHarness from "./views/TestHarness"
+import LayoutEffectHarness from "./views/LayoutEffectHarness"
 import "./index.css"
 
 const rootElement = document.getElementById("root")
@@ -19,6 +21,8 @@ root.render(
       <Route path="/" element={<DancingPoints />} />
       <Route path="/color-cube" element={<ColorCube />} />
       <Route path="/simple-example" element={<SimpleExample />} />
+      <Route path="/test-harness" element={<TestHarness />} />
+      <Route path="/layout-effect-harness" element={<LayoutEffectHarness />} />
     </Routes>
   </BrowserRouter>
 )

--- a/packages/examples/src/playwright/layout-effect-atomic-mount.spec.ts
+++ b/packages/examples/src/playwright/layout-effect-atomic-mount.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-underscore-dangle */
+import { test, expect } from "@playwright/test"
+
+/** One per-frame node-count sample, recorded by the LayoutEffectHarness view. */
+type MbFrame = { frame: number; groups: number; grids: number }
+declare global {
+  interface Window {
+    __mbFrames?: MbFrame[]
+  }
+}
+
+/**
+ * Pins the `useLayoutEffect` timing of the node-creation effects in the factory
+ * (`components.tsx`) and root (`Mathbox.tsx`): the whole mathbox scene graph is
+ * built in a single synchronous, pre-paint commit, so every node exists on the
+ * very first animation frame after mount.
+ *
+ * If those effects revert to `useEffect` (passive), the build is deferred past
+ * the first paint and the tree fills in over several frames instead — measured
+ * here, frame 0 is empty and the 8-deep tree isn't complete until ~frame 4
+ * (later still under CPU load). This test fails in that case because the first
+ * sampled frame is incomplete.
+ *
+ * The `/layout-effect-harness` view renders an 8-level-deep tree — each level a
+ * `<Group>` holding a renderable `<Grid>` (a real warmup participant, so the
+ * passive-effect build spreads over a wide, non-flaky margin) — and records the
+ * node counts once per animation frame into `window.__mbFrames`.
+ */
+test.describe("layout-effect atomic mount", () => {
+  test("builds the entire scene graph on the first animation frame", async ({
+    page,
+  }) => {
+    await page.goto("/layout-effect-harness")
+
+    // Wait until the per-frame samples settle (the tree stops growing).
+    await page.waitForFunction(() => {
+      const f = window.__mbFrames
+      if (!f || f.length < 12) return false
+      const last = f[f.length - 1]
+      return (
+        last.grids > 0 &&
+        f
+          .slice(-6)
+          .every((x) => x.grids === last.grids && x.groups === last.groups)
+      )
+    })
+
+    const frames = await page.evaluate(() => window.__mbFrames ?? [])
+    const first = frames[0]
+    const settled = frames[frames.length - 1]
+
+    // Sanity: the deep tree actually built (8 nested groups, each with a grid).
+    expect(settled).toMatchObject({ groups: 8, grids: 8 })
+
+    // The heart of the test: the first sampled frame already holds the whole
+    // tree — it was built atomically in one commit, not filled in over frames.
+    // Under `useEffect` this frame would be empty (0 groups, 0 grids).
+    expect(first.groups).toBe(settled.groups)
+    expect(first.grids).toBe(settled.grids)
+  })
+})

--- a/packages/examples/src/playwright/smoke.spec.ts
+++ b/packages/examples/src/playwright/smoke.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-underscore-dangle */
+import { test, expect } from "@playwright/test"
+
+/**
+ * Real-browser smoke test: renders a scene with the actual library, a real
+ * mathbox instance, and a real WebGL context, then asserts the scene graph was
+ * built correctly. The jsdom unit tests exercise the same code against a fake
+ * WebGL automock, so this is the only coverage that would catch a breakage that
+ * only surfaces with a real browser / real three.js.
+ *
+ * `window.__mbRoot` is populated by the TestHarness view.
+ */
+test.describe("real-browser mount", () => {
+  test("builds the mathbox scene graph in a real WebGL context", async ({
+    page,
+  }) => {
+    await page.goto("/test-harness")
+
+    await page.waitForFunction(
+      () => !!(window as unknown as { __mbRoot?: unknown }).__mbRoot
+    )
+
+    const counts = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const root = (window as any).__mbRoot
+      return {
+        cartesian: root.select("cartesian").length,
+        group: root.select("group").length,
+        axis: root.select("axis").length,
+        grid: root.select("grid").length,
+      }
+    })
+
+    expect(counts).toEqual({ cartesian: 1, group: 1, axis: 2, grid: 2 })
+  })
+})

--- a/packages/examples/src/views/LayoutEffectHarness.tsx
+++ b/packages/examples/src/views/LayoutEffectHarness.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable no-underscore-dangle */
+import React, { useCallback, useLayoutEffect } from "react"
+import { ContainedMathbox, Cartesian, Group, Grid } from "mathbox-react"
+import type { MathboxSelection } from "mathbox"
+
+/**
+ * Deep-tree harness for the useEffect-vs-useLayoutEffect regression test.
+ *
+ * The two effect timings build an *identical* final tree; they differ only in
+ * how many animation frames the build takes. The factory creates each node in
+ * an effect and only exposes a real parent to its children after that effect
+ * runs, so the tree builds one level per `effect -> forceUpdate -> re-render`
+ * cycle:
+ *   - useLayoutEffect: the whole cascade flushes synchronously, before paint,
+ *     so the entire tree exists on the very first animation frame.
+ *   - useEffect (passive): each level flushes after a paint, so the tree fills
+ *     in over several frames.
+ *
+ * To observe that we need (a) a *deep* tree and (b) a *per-frame* measurement.
+ * Each level also holds a renderable `Grid` — a real warmup participant — so
+ * the passive-effect build spreads over a comfortably wide, non-flaky margin
+ * rather than collapsing into a single deferred frame the way a groups-only
+ * tree does. We record, once per animation frame, how many nodes exist yet.
+ */
+declare global {
+  interface Window {
+    __mbRoot?: MathboxSelection<"root"> | null
+    __mbFrames?: Array<{ frame: number; groups: number; grids: number }>
+  }
+}
+
+const LayoutEffectHarness: React.FC = () => {
+  const handleRoot = useCallback((root: MathboxSelection<"root"> | null) => {
+    window.__mbRoot = root
+  }, [])
+
+  // Sample the node counts once per frame, starting as early as possible.
+  useLayoutEffect(() => {
+    window.__mbFrames = []
+    let frame = 0
+    let raf = 0
+    const tick = () => {
+      const root = window.__mbRoot
+      const groups = root ? root.select("group").length : 0
+      const grids = root ? root.select("grid").length : 0
+      window.__mbFrames?.push({ frame, groups, grids })
+      frame += 1
+      if (frame < 40) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  return (
+    <ContainedMathbox
+      ref={handleRoot}
+      options={{ plugins: ["core"] }}
+      containerStyle={{ height: "100vh" }}
+    >
+      <Cartesian>
+        <Group>
+          <Grid axes="xy" />
+          <Group>
+            <Grid axes="xy" />
+            <Group>
+              <Grid axes="xy" />
+              <Group>
+                <Grid axes="xy" />
+                <Group>
+                  <Grid axes="xy" />
+                  <Group>
+                    <Grid axes="xy" />
+                    <Group>
+                      <Grid axes="xy" />
+                      <Group>
+                        <Grid axes="xy" />
+                      </Group>
+                    </Group>
+                  </Group>
+                </Group>
+              </Group>
+            </Group>
+          </Group>
+        </Group>
+      </Cartesian>
+    </ContainedMathbox>
+  )
+}
+
+export default LayoutEffectHarness

--- a/packages/examples/src/views/TestHarness.tsx
+++ b/packages/examples/src/views/TestHarness.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable no-underscore-dangle */
+import React, { useCallback } from "react"
+import { ContainedMathbox, Cartesian, Group, Axis, Grid } from "mathbox-react"
+import type { MathboxSelection } from "mathbox"
+
+/**
+ * A small, deterministic scene used by the Playwright smoke test. It exposes
+ * the root selection on `window` so the test can assert — in a real browser
+ * with a real WebGL context — that the library builds mathbox's scene graph
+ * correctly. (The jsdom unit tests run against a fake WebGL automock, so they
+ * can't catch real-browser integration breakage.)
+ */
+declare global {
+  interface Window {
+    __mbRoot?: MathboxSelection<"root"> | null
+  }
+}
+
+const TestHarness: React.FC = () => {
+  const handleRoot = useCallback((root: MathboxSelection<"root"> | null) => {
+    window.__mbRoot = root
+  }, [])
+
+  return (
+    <ContainedMathbox
+      ref={handleRoot}
+      options={{ plugins: ["core"] }}
+      containerStyle={{ height: "100vh" }}
+    >
+      <Cartesian>
+        <Group>
+          <Axis axis="x" />
+          <Axis axis="y" />
+          <Grid axes="xy" />
+          <Grid axes="xz" />
+        </Group>
+      </Cartesian>
+    </ContainedMathbox>
+  )
+}
+
+export default TestHarness

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -16,6 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "playwright.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/examples/tsconfig.node.json
+++ b/packages/examples/tsconfig.node.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/examples/vite.config.ts
+++ b/packages/examples/vite.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
+import path from "path"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      // Resolve the workspace library to its TypeScript source so the examples
+      // app (and the Playwright e2e tests) always exercise current source with
+      // no build step. Exact-match only, so `mathbox-react/threestrap` is
+      // unaffected.
+      {
+        find: /^mathbox-react$/,
+        replacement: path.resolve(__dirname, "../mathbox-react/src/index.ts"),
+      },
+    ],
+  },
 })

--- a/packages/mathbox-react/src/components/Mathbox.tsx
+++ b/packages/mathbox-react/src/components/Mathbox.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect,
+  useLayoutEffect,
   useState,
   forwardRef,
   useImperativeHandle,
@@ -27,7 +27,7 @@ const Mathbox = (
   const [selection, setSelection] = useState<MathboxSelection<"root"> | null>(
     null
   )
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!container) return () => {}
 
     const mathbox = mathBox({
@@ -48,7 +48,7 @@ const Mathbox = (
     }
   }, [container, mathboxOptions])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!selection) return
     selection.set(rootProps)
   }, [selection, rootProps])

--- a/packages/mathbox-react/src/components/components.tsx
+++ b/packages/mathbox-react/src/components/components.tsx
@@ -2,7 +2,7 @@ import React, {
   forwardRef,
   useRef,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useReducer,
   useImperativeHandle,
 } from "react"
@@ -40,7 +40,7 @@ const mathboxComponentFactory = <T extends NodeType>(
     const parent = useContext(MathboxAPIContext)
     const selection = useRef<MathboxSelection<T> | null>(null)
     const prevLiveProps = useRef<LiveProps<Props[T]> | undefined>(undefined)
-    useEffect(
+    useLayoutEffect(
       () => () => {
         if (selection.current) {
           selection.current.remove()
@@ -52,7 +52,7 @@ const mathboxComponentFactory = <T extends NodeType>(
     useImperativeHandle(ref, () => selection.current)
 
     const { children, liveProps, ...others } = props
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (!parent) return
       if (isRootDestroyed(parent)) {
         forceUpdate()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5225,6 +5225,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.49":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
+  dependencies:
+    playwright: 1.61.1
+  bin:
+    playwright: cli.js
+  checksum: cf664aa3f5ccc63061ec8a96cf957ad2160b0a300035b310b9fcf67da43f52681fb775755c6134230e0ace7b391a08d9cfe7ca9664546d1bb5d4cf02e1db170a
+  languageName: node
+  linkType: hard
+
 "@radix-ui/number@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/number@npm:1.0.1"
@@ -7528,7 +7539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.0.9":
+"@types/react-dom@npm:^18.0.0":
   version: 18.0.10
   resolution: "@types/react-dom@npm:18.0.10"
   dependencies:
@@ -7537,7 +7548,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^18.0.26":
+"@types/react-dom@npm:^18.2.0":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: c8b63ec944d2a68992b4dba474003fe55ee1d949c4b9c8fe97eecb2290de23f76acfb670b2f7ceb46a5fc8e46808d1745369b03edda48a7a0cf730eff4c5d315
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*":
   version: 18.0.26
   resolution: "@types/react@npm:18.0.26"
   dependencies:
@@ -11943,8 +11963,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "examples@workspace:packages/examples"
   dependencies:
-    "@types/react": ^18.0.26
-    "@types/react-dom": ^18.0.9
+    "@playwright/test": ^1.49
+    "@types/react": 18.2.28
+    "@types/react-dom": ^18.2.0
     "@types/three": 0.148.0
     "@vitejs/plugin-react": ^6
     eslint: ^8.32.0
@@ -12527,6 +12548,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: latest
+  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^1.2.7":
   version: 1.2.13
   resolution: "fsevents@npm:1.2.13"
@@ -12534,16 +12565,6 @@ __metadata:
     bindings: ^1.5.0
     nan: ^2.12.1
   checksum: ae855aa737aaa2f9167e9f70417cf6e45a5cd11918e1fee9923709a0149be52416d765433b4aeff56c789b1152e718cd1b13ddec6043b78cdda68260d86383c1
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
-  dependencies:
-    node-gyp: latest
-  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -12558,21 +12579,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: latest
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@patch:fsevents@^1.2.7#~builtin<compat/fsevents>":
   version: 1.2.13
   resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=d11327"
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: latest
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -16110,6 +16131,30 @@ __metadata:
   dependencies:
     find-up: ^6.3.0
   checksum: 94298b20a446bfbbd66604474de8a0cdd3b8d251225170970f15d9646f633e056c80520dd5b4c1d1050c9fed8f6a9e5054b141c93806439452efe72e57562c03
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 69bd5c4eb1884a16e92674c0399ad25120ce91faecadd25227cb07eaa0892cce07f908c6bad51256363bf17634953759c30d42d7c253128c28bc8b86087a1f62
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: 2.3.2
+    playwright-core: 1.61.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 2d85be1b6a88dbeeb206c5800629182840f07bd0e5e74f154fa57de2f1df16631918df9139a1cb8ddde8f2f125c5c9e447686a0fdadb61552b668ba97ffcaaf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Switches the node-creation effects in the component factory (`components.tsx`) and the root `Mathbox` component from `useEffect` to `useLayoutEffect`, and adds a real-browser Playwright test that pins the resulting behavior.

## Why

Each factory node only exposes a real parent selection to its children *after* its effect runs, so the tree builds one level per commit. With passive effects that cascade is deferred past paint and spreads across several animation frames; with layout effects it flushes synchronously in a single pre-paint commit, so the whole scene graph exists on the first frame.

## The regression test

The two effect timings build an **identical final tree** — they differ only in *how many frames* the build takes, so any assertion on the settled outcome sees no difference. `LayoutEffectHarness` renders an 8-deep tree of nested `<Group>`s (each with a renderable `<Grid>`, a real warmup participant that widens the margin) and records how many nodes exist per animation frame. `layout-effect-atomic-mount.spec` asserts the whole tree exists on the **first sampled frame**:

- `useLayoutEffect` → complete on frame 0 (verified 15+ runs, immune to CPU throttling)
- `useEffect` → frame 0 empty, tree fills in over ~4 frames (~8 under 4× throttle)

Runs headless in real WebGL via SwiftShader. A structural `smoke.spec` is included too.

## Examples type-checking fixes (bundled)

The examples app had 53 `tsc` errors (now 0), unrelated to the change above but touched while adding the typed test files:

- **Dedupe `@types/react`.** The library pins exact `18.2.28` while examples pinned `^18.0.26` and kept its own `18.0.26` copy — two physical copies made every component fail *"cannot be used as a JSX component."* Aligned examples to the exact same version so install yields one copy.
- **tsconfig project-refs hygiene.** `vite.config.ts` is now typechecked by the node-tooling tsconfig (bundler resolution), not the browser-app tsconfig, which under `node` resolution can't read Vite 8's `exports`-based types.
- **examples-local `.eslintrc`** points the type-aware parser at both tsconfigs so lint still covers `vite.config.ts`.

Known residual (out of scope): `tsc -b tsconfig.node.json` still shows parse errors inside `@vitejs/plugin-react@6`'s own `.d.ts` under TS 5.2.2 — nothing in CI runs it; app config + lint are clean. Proper fix is a TypeScript bump.

## Verification

`yarn lint` ✅ · `yarn test` (13/13) ✅ · examples `tsc` 0 errors ✅ · Playwright 2/2 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)