### PR TITLE
Fix flaky <Voxel> test that leaked an unhandled error into CI

### DIFF
--- a/packages/mathbox-react/src/components/components.spec.tsx
+++ b/packages/mathbox-react/src/components/components.spec.tsx
@@ -295,18 +295,37 @@ describe("Cartesian", () => {
 
 describe("<Voxel />", () => {
   it("throws a runtime error if it has children", () => {
-    const willThrow = () =>
-      render(
-        <ContainedMathbox>
-          <Cartesian>
-            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment  */}
-            {/* @ts-expect-error */}
-            <Voxel>
-              <Grid />
-            </Voxel>
-          </Cartesian>
-        </ContainedMathbox>
-      )
-    expect(willThrow).toThrow("Component <Voxel /> cannot have children.")
+    /**
+     * In development React re-dispatches errors thrown during render through a
+     * `window` "error" event (invokeGuardedCallbackDev) in addition to
+     * rethrowing them to the caller. Vitest's global "error" listener collects
+     * that expected error as an unhandled error and fails the run — observed
+     * intermittently in CI. Calling preventDefault on the matching event marks
+     * it handled, which suppresses Vitest's collection, while `render` still
+     * throws so the assertion below holds.
+     */
+    const suppressExpectedError = (event: ErrorEvent) => {
+      if (event.error?.message?.includes("cannot have children")) {
+        event.preventDefault()
+      }
+    }
+    window.addEventListener("error", suppressExpectedError)
+    try {
+      const willThrow = () =>
+        render(
+          <ContainedMathbox>
+            <Cartesian>
+              {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment  */}
+              {/* @ts-expect-error */}
+              <Voxel>
+                <Grid />
+              </Voxel>
+            </Cartesian>
+          </ContainedMathbox>
+        )
+      expect(willThrow).toThrow("Component <Voxel /> cannot have children.")
+    } finally {
+      window.removeEventListener("error", suppressExpectedError)
+    }
   })
 })


### PR DESCRIPTION
## What

Stops the `<Voxel />` test in `components.spec.tsx` from intermittently failing CI. It now scopes a `window` \"error\" listener around the assertion that marks the *expected* render error as handled (`preventDefault`), so Vitest no longer collects it as an unhandled error.

## Root cause

The test asserts that rendering `<Voxel>` with children throws. In development, React does not only rethrow render errors to the caller — `invokeGuardedCallbackDev` (react-dom 18.1) **re-dispatches the error through a `window` "error" event** and its own handler never calls `preventDefault()`. That expected error therefore reaches Vitest's global `"error"` listener, which collects it as an unhandled error and fails the run:

```
⎯ Unhandled Errors ⎯
Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. ...
Error: Component <Voxel /> cannot have children.
```

Whether the collection lands is environment/timing-dependent: it surfaced in CI (Linux jsdom) while passing locally on macOS (0 failures in 50+ runs).

## Why this fix (verified, not guessed)

- Read the react-dom 18.1 dispatch path confirming the `window`-"error" channel with no `preventDefault`.
- Reproduced the channel deterministically (an error thrown inside a jsdom event-listener dispatch): **8/8 runs leak** to Vitest with the same message.
- Adding a `window` "error" listener that `preventDefault()`s the matching error: **0/8 leak**. Confirms Vitest honors `preventDefault` (its bundle never checks `defaultPrevented`, so this was the load-bearing unknown).

The suppression is scoped to the `"cannot have children"` message and removed in `finally`, so genuine unhandled errors elsewhere still fail the run. As a bonus it also silences React's console logging of the expected error.

## Verification

`yarn lint` ✅ · `yarn test` (13/13) ✅ · 10/10 local loop green · expected error no longer leaks to stderr (2 lines → 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)