### PR TITLE
feat: finalize release automation and document the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,23 @@ The project uses [Yarn](https://yarnpkg.com/getting-started/install) and include
 - [examples](./example/) Examples using `mathbox-react`.
 
 See individual `package.json` files for available commands. In general, commands should be run via `yarn`, not `npm`. E.g., `yarn install` or `yarn lint`.
+
+## Releasing
+
+Releases are automated with [semantic-release](https://semantic-release.gitbook.io/). The published version and changelog are derived from the [Conventional Commit](https://www.conventionalcommits.org/) titles of the pull requests merged since the previous release (each PR is squash-merged, so its title becomes the commit message; the `Lint PR` check enforces the format).
+
+Which commit types cut a release:
+
+| Type | Release |
+| --- | --- |
+| `feat:` | minor |
+| `fix:`, `perf:`, `refactor:`, `revert:`, `build:` | patch |
+| `feat!:` / `BREAKING CHANGE:` | major |
+| `docs:`, `test:`, `ci:`, `style:`, `chore:` | none |
+
+Dependency updates follow the same rules: [Renovate](https://docs.renovatebot.com/) is configured for semantic commits, so bumps to runtime `dependencies` are titled `fix(deps):` (releasing a patch) while dev/tooling bumps are `chore(deps):` (no release).
+
+To publish, trigger the **Releases (Semantic & Pre-release)** workflow from the Actions tab (`workflow_dispatch`):
+
+- `semantic-release` — cut a real release from `main` (publishes to npm + creates the GitHub release).
+- `pre-release` — publish a throwaway `0.0.0-<sha>` version under the `preview` npm tag from any branch, for testing before merge.

--- a/packages/mathbox-react/.releaserc.json
+++ b/packages/mathbox-react/.releaserc.json
@@ -4,7 +4,12 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "refactor", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "build", "release": "patch" }
+        ]
       }
     ],
     [
@@ -13,22 +18,14 @@
         "preset": "conventionalcommits",
         "presetConfig": {
           "types": [
-            {
-              "type": "feat",
-              "section": "Features"
-            },
-            {
-              "type": "fix",
-              "section": "Bug Fixes"
-            },
-            {
-              "type": "chore",
-              "section": "Miscellaneous"
-            },
-            {
-              "type": "docs",
-              "section": "Miscellaneous"
-            }
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "build", "section": "Build System" },
+            { "type": "chore", "section": "Miscellaneous" },
+            { "type": "docs", "section": "Miscellaneous" }
           ]
         }
       }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticPrefixFixDepsChoreOthers"],
+  "semanticCommits": "enabled"
+}


### PR DESCRIPTION
Refines the release setup from #358 so more change types reach consumers, teaches Renovate to emit semantic commits, and documents the process. Also serves as the first releasing commit — merging this cuts `1.0.0`.

## Changes

**Release rules** (`.releaserc.json`)
- `commit-analyzer`: also release a **patch** on `refactor:`, `revert:`, and `build:` — these ship code or change the published artifact, so they shouldn't be stranded unreleased. `feat`/`fix`/`perf`/breaking keep their defaults; `docs`/`test`/`ci`/`style`/`chore` stay non-releasing.
- `release-notes-generator`: added changelog sections for the newly-releasing types (plus `perf`) so a release triggered by them isn't blank.

**Semantic Renovate** (`renovate.json`, new)
- Enables semantic commits with `:semanticPrefixFixDepsChoreOthers`: runtime `dependencies` bumps become `fix(deps):` (release a patch), dev/tooling bumps become `chore(deps):` (no release). This targets exactly the consumer-relevant subset — the published package has one runtime dep (`lodash`) vs 27 devDeps.
- Also a **required fix**: Renovate currently titles PRs `Update dependency ...`, which is not a Conventional Commit and would now fail the `Lint PR` check added in #358.
- Extends `config:recommended` as the baseline — this may adjust Renovate's grouping/scheduling from whatever defaults were in effect.

**Docs** (`README.md`)
- Documents the release flow, the commit-type → version mapping, and the manual `semantic-release` / `pre-release` workflows.

## Notes
- First release will be `1.0.0` (no prior tags), regardless of bump type.
- Not touching the pre-existing README typos (e.g. "pbulished") to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)