### PR TITLE
fix: build before publish instead of via prepack hook

### DIFF
--- a/.github/workflows/_reusable-semantic-release.yml
+++ b/.github/workflows/_reusable-semantic-release.yml
@@ -24,6 +24,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --immutable
+      # Build here, before semantic-release bumps the version. The package
+      # publishes its prebuilt `build/` dir; we can't build during `npm publish`
+      # (via a `prepack` hook) because the version bump makes yarn.lock stale and
+      # CI runs Yarn in immutable mode, so any Yarn resolve at that point fails.
+      - name: Build
+        run: yarn build
       - name: Release
         working-directory: packages/mathbox-react
         env:

--- a/packages/mathbox-react/package.json
+++ b/packages/mathbox-react/package.json
@@ -30,7 +30,6 @@
     "build-watch": "tsc --watch",
     "storybook": "start-storybook -p 6006",
     "lint": "eslint \"**/*.ts?(x)\"",
-    "prepack": "yarn build",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Why

semantic-release now computes the version (`1.0.0`) and reaches the npm publish step, but fails inside the package's `prepack` hook:

```
> mathbox-react@1.0.0 prepack
> yarn build
Internal Error: mathbox-react-root@workspace:.: This package doesn't seem to be
present in your lockfile; run "yarn install" to update the lockfile
```

`@semantic-release/npm` bumps the version (`npm version 1.0.0`) and then runs `npm publish`, which fires `prepack: yarn build`. That `yarn build` triggers a Yarn project **resolve** — but the version bump has just made `yarn.lock` stale, and **CI runs Yarn in immutable mode**, so the resolve hard-fails instead of quietly updating.

## Fix

- Add an explicit **Build** step to the release workflow, *before* semantic-release runs — while the lockfile is still consistent (version `0.0.0`).
- Drop the `prepack: yarn build` hook, so `npm publish` just packs the prebuilt `build/` dir and never invokes Yarn after the version bump.

The package's `files` is `["build"]`, so the prebuilt dir is exactly what gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)